### PR TITLE
Added option to configure proxy server for CF deployment

### DIFF
--- a/src/main/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher.java
+++ b/src/main/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher.java
@@ -18,9 +18,11 @@ import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
+
 import org.cloudfoundry.client.lib.CloudCredentials;
 import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.cloudfoundry.client.lib.CloudFoundryException;
+import org.cloudfoundry.client.lib.HttpProxyConfiguration;
 import org.cloudfoundry.client.lib.StartingInfo;
 import org.cloudfoundry.client.lib.domain.*;
 import org.cloudfoundry.client.lib.org.springframework.web.client.ResourceAccessException;
@@ -28,6 +30,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -48,6 +51,7 @@ public class CloudFoundryPushPublisher extends Recorder {
     public final String username;
     public final String password;
     public final boolean selfSigned;
+    public final String proxy;
     public final boolean resetIfExists;
     public final OptionalManifest optionalManifest;
 
@@ -56,7 +60,7 @@ public class CloudFoundryPushPublisher extends Recorder {
 
     @DataBoundConstructor
     public CloudFoundryPushPublisher(String target, String organization, String cloudSpace,
-                                     String username, String password, boolean selfSigned,
+                                     String username, String password, boolean selfSigned, String proxy,
                                      boolean resetIfExists, OptionalManifest optionalManifest) {
         this.target = target;
         this.organization = organization;
@@ -64,6 +68,7 @@ public class CloudFoundryPushPublisher extends Recorder {
         this.username = username;
         this.password = password;
         this.selfSigned = selfSigned;
+        this.proxy = proxy;
         this.resetIfExists = resetIfExists;
         this.optionalManifest = optionalManifest;
     }
@@ -89,8 +94,10 @@ public class CloudFoundryPushPublisher extends Recorder {
             setAppURI("https://" + deploymentInfo.getHostname() + "." + deploymentInfo.getDomain());
 
             CloudCredentials credentials = new CloudCredentials(username, password);
+            HttpProxyConfiguration proxyConfig = buildProxyConfiguration(proxy);
+            
             CloudFoundryClient client = new CloudFoundryClient(credentials, targetUrl, organization, cloudSpace,
-                    null, selfSigned);
+            		proxyConfig, selfSigned);
             client.login();
 
             listener.getLogger().println("Pushing " + appName + " app to " + target);
@@ -289,6 +296,22 @@ public class CloudFoundryPushPublisher extends Recorder {
     public void setAppURI(String appURI) {
         this.appURI = appURI;
     }
+    
+    private static HttpProxyConfiguration buildProxyConfiguration(String proxy)
+    {
+        if (proxy == null || proxy.trim().length() == 0)
+        	return null;
+        
+        try
+        {
+			URL url = new URL(proxy);
+			return new HttpProxyConfiguration(url.getHost(), url.getPort());
+        }
+        catch (MalformedURLException e)
+        {
+        	throw new IllegalArgumentException("Malformed Proxy URL", e);
+        }
+    }
 
     public static class OptionalManifest {
         public final String appName;
@@ -371,13 +394,16 @@ public class CloudFoundryPushPublisher extends Recorder {
                                                @QueryParameter("password") final String password,
                                                @QueryParameter("organization") final String organization,
                                                @QueryParameter("cloudSpace") final String cloudSpace,
-                                               @QueryParameter("selfSigned") final boolean selfSigned) {
+                                               @QueryParameter("selfSigned") final boolean selfSigned,
+                                               @QueryParameter("proxy") final String proxy) {
 
             try {
                 URL targetUrl = new URL(target);
                 CloudCredentials credentials = new CloudCredentials(username, password);
+                HttpProxyConfiguration proxyConfig = buildProxyConfiguration(proxy);
+                
                 CloudFoundryClient client = new CloudFoundryClient(credentials, targetUrl, organization, cloudSpace,
-                        null, selfSigned);
+                        proxyConfig, selfSigned);
                 client.login();
                 client.getCloudInfo();
                 if (targetUrl.getHost().startsWith("api.")) {

--- a/src/main/resources/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher/config.jelly
+++ b/src/main/resources/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher/config.jelly
@@ -18,8 +18,11 @@
   <f:entry title="Allow self-signed certificate" field="selfSigned">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="Proxy" field="proxy">
+    <f:textbox/>
+  </f:entry>
   <f:validateButton title="Test Connection" progress="Testing..."
-                    method="testConnection" with="target,username,password,organization,cloudSpace,selfSigned"/>
+                    method="testConnection" with="target,username,password,organization,cloudSpace,selfSigned,proxy"/>
   <f:entry title="Reset app if already exists" field="resetIfExists">
     <f:checkbox/>
   </f:entry>

--- a/src/test/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisherTest.java
+++ b/src/test/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisherTest.java
@@ -78,7 +78,7 @@ public class CloudFoundryPushPublisherTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, null);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, null);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -109,7 +109,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, manifest);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, manifest);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -141,7 +141,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf1 = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, true, manifest1);
+                TEST_USERNAME, TEST_PASSWORD, false, null, true, manifest1);
         project.getPublishersList().add(cf1);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " 1 completed");
@@ -160,7 +160,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf2 = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, true, manifest2);
+                TEST_USERNAME, TEST_PASSWORD, false, null, true, manifest2);
         project.getPublishersList().add(cf2);
         build = project.scheduleBuild2(0).get();
 
@@ -181,7 +181,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, manifest);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, manifest);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -213,7 +213,7 @@ public class CloudFoundryPushPublisherTest {
                         "https://github.com/heroku/heroku-buildpack-nodejs", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, manifest);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, manifest);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -246,7 +246,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, manifest);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, manifest);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -265,7 +265,7 @@ public class CloudFoundryPushPublisherTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("python-env.zip")));
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, null);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, null);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -306,7 +306,7 @@ public class CloudFoundryPushPublisherTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("python-env-services.zip")));
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, null);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, null);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -338,7 +338,7 @@ public class CloudFoundryPushPublisherTest {
                         "target/hello-java-1.0.war", "", "", "",
                         new ArrayList<EnvironmentVariable>(), new ArrayList<ServiceName>());
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, manifest);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, manifest);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -362,7 +362,7 @@ public class CloudFoundryPushPublisherTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher("https://does-not-exist.local", TEST_ORG, TEST_SPACE,
-                TEST_USERNAME, TEST_PASSWORD, false, false, null);
+                TEST_USERNAME, TEST_PASSWORD, false, null, false, null);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
@@ -379,7 +379,7 @@ public class CloudFoundryPushPublisherTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));
         CloudFoundryPushPublisher cf = new CloudFoundryPushPublisher(TEST_TARGET, TEST_ORG, TEST_SPACE,
-                "NotAdmin", "BadPassword", false, false, null);
+                "NotAdmin", "BadPassword", false, null, false, null);
         project.getPublishersList().add(cf);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");


### PR DESCRIPTION
In our internal build landscape, I have to pass the proxy configuration to the CF client.

This change simply adds a new propertry ("proxy server"). Alternatively, one could build the proxy configuration automatically out of the Jenkins server configuration. I dedicded against it, because this might not be the configuration one wants to use.