### PR TITLE
Use proxy configuration when connecting to CloudFoundry

### DIFF
--- a/src/main/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher.java
+++ b/src/main/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisher.java
@@ -7,9 +7,11 @@ package com.activestate.cloudfoundryjenkins;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.ProxyConfiguration;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Hudson;
 import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -33,16 +35,13 @@ import org.kohsuke.stapler.QueryParameter;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import java.io.*;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class CloudFoundryPushPublisher extends Recorder {
 
@@ -348,22 +347,17 @@ public class CloudFoundryPushPublisher extends Recorder {
     
     private static HttpProxyConfiguration buildProxyConfiguration(URL targetURL)
     {
-        try {
-            List<Proxy> proxies = ProxySelector.getDefault().select(targetURL.toURI());
-            if (proxies.isEmpty() || proxies.get(0).equals(Proxy.NO_PROXY))
+    	ProxyConfiguration proxyConfig = Hudson.getInstance().proxy;
+    	if (proxyConfig == null)
+    		return null;
+    	
+    	String host = targetURL.getHost();
+    	for (Pattern p : proxyConfig.getNoProxyHostPatterns()) {
+    	    if (p.matcher(host).matches())
                 return null;
-			
-            Proxy proxy = proxies.get(0);
-            if (proxy.type() != Proxy.Type.HTTP)
-                return null;
-            if (!(proxy.address() instanceof InetSocketAddress))
-                return null;
-
-            InetSocketAddress isa = (InetSocketAddress)proxy.address();
-            return new HttpProxyConfiguration(isa.getHostString(), isa.getPort());
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Illegal target URL", e);
-        }
+		}
+    	
+    	return new HttpProxyConfiguration(proxyConfig.name, proxyConfig.port);
     }
 
     public static class OptionalManifest {


### PR DESCRIPTION
Instead of requiring an explicit configuration of the proxy, this change uses the configured proxies by the Java Virtual Machine.

This change will not use the proxy configuration which is done in "configure jenkins" -> "manage plug-ins" -> "advanced". To me, that seems to be specific to the update mechanism.

Feel free to use.